### PR TITLE
Revert "Allow a custom bin/prep_local script to prepare the local Ruby environment, if it exists"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,3 @@
-## Version 1.2
-
-* Allow a custom bin/prep_local script to prepare the local Ruby environment, if it exists.
-
 ## Version 1.1.2
 
 * Protect more git actions with `&&` piping.

--- a/git-aliases.plugin.zsh
+++ b/git-aliases.plugin.zsh
@@ -54,11 +54,7 @@ rp() {
 }
 
 rb() {
-  if [ -f bin/prep_local ]; then
-    bin/prep_local
-  else
-    bundle install && bundle exec rake db:migrate && bundle exec rake db:test:prepare && bundle exec rake db:seed
-  fi
+  bundle install && bundle exec rake db:migrate && bundle exec rake db:test:prepare && bundle exec rake db:seed
 }
 
 corp() {


### PR DESCRIPTION
Reverts peterhurford/git-aliases.zsh#17 -- this turned out to be a bad idea. :-1: 